### PR TITLE
Leave out focus item when action is Search or Navigate

### DIFF
--- a/mm_action_prediction/tools/extract_actions.py
+++ b/mm_action_prediction/tools/extract_actions.py
@@ -1185,7 +1185,9 @@ def get_carousel_state(state=None, action_args=None):
         for order in search_order_carousel:
             if state[order]:
                 new_state["carousel"] = state[order]
-                break
+                # break loop and return - don't return focus item
+                # SearchFurniture and NavigateCarousel actions
+                return new_state
     elif action in [ROTATE_ACTION, FOCUS_ON_FURNITURE_ACTION]:
         focus_id = action_args["args"]["furniture_id"]
         for order in search_order_carousel:


### PR DESCRIPTION
SearchFurniture and NavigateCarousel actions result in views
of the carousel so don't need to include any previous in-focus
items. These are implicity removed by these two actions.