### PR TITLE
Setting turn_carousel_state based on 'Share'

### DIFF
--- a/mm_action_prediction/tools/extract_actions.py
+++ b/mm_action_prediction/tools/extract_actions.py
@@ -1111,16 +1111,15 @@ def get_roundwise_dialog_actions(subtask, dialog_actions):
 
         # Go through all the raw_actions to get the next turn_state.
         raw_actions = turn_datum["raw_action_with_args"]
-        if len(raw_actions):
-            turn_carousel_state = {
-                "focus": raw_actions[-1][NEXT_STATE][SHARED_FOCUS],
-                "carousel": raw_actions[-1][NEXT_STATE][SHARED_CAROUSEL],
-            }
-        else:
-            turn_carousel_state = action_output_state
+        for raw_act in raw_actions:
+            if raw_act[API] == "Share":
+                turn_carousel_state = {
+                    "focus": raw_act[NEXT_STATE][SHARED_FOCUS],
+                    "carousel": raw_act[NEXT_STATE][SHARED_CAROUSEL],
+                }
 
         # Also record the final carousel_state.
-        action_datum["final_carousel_state"] = deepcopy.copy(turn_carousel_state)
+        action_datum["final_carousel_state"] = copy.deepcopy(turn_carousel_state)
         roundwise_actions.append(action_datum)
     return roundwise_actions
 


### PR DESCRIPTION
Raw actions are split by messages, not necessarily by when sharing occurs (unlike consolidated relevant_actions).

This is especially noticeable when, say, a SpecifyInfo action/message is inserted which doesn't often align with a share action. In such cases extracting the final shared state from the last raw action in a turn is giving unexpected results. Updated to use the 'Share' raw-action to determine the final scene as seen by the user at end of a turn.

Thinking about it some more, the previous version of the code should have worked given that the only information being copied from the last raw action is the shared state of the in-focus and carousel items. Looks like there's some misalignment of expectations about the  raw logging which makes the shared status only reliable when a Share occurs.